### PR TITLE
Implementar control de acceso basado en roles para secciones

### DIFF
--- a/app/Http/Controllers/EstanteriaController.php
+++ b/app/Http/Controllers/EstanteriaController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Estanteria;
+use App\Models\Seccion;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -19,8 +20,29 @@ class EstanteriaController extends Controller
         $page = max(1, (int) $request->input('page', 1));
         $perPage = 20; // Valor fijo de 20 elementos por página
 
-        // Query base
-        $query = Estanteria::query()->orderBy('cod_estante');
+        // Query base con relación de sección
+        $query = Estanteria::with('seccion')->orderBy('cod_estante');
+
+        // Filtrar por sección según el rol del usuario
+        $user = $request->user();
+        $seccionId = null;
+        
+        if ($user->hasRole('BibliotecarioPrimaria')) {
+            $seccion = Seccion::where('nombre', 'PRIMARIA')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+            if ($seccionId) {
+                $query->where('seccion_id', $seccionId);
+            }
+        } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+            $seccion = Seccion::where('nombre', 'BACHILLERATO')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+            if ($seccionId) {
+                $query->where('seccion_id', $seccionId);
+            }
+        }
+        
+        // Obtener todas las secciones para el formulario
+        $allSecciones = Seccion::all();
 
         // Aplicar filtros de búsqueda
         if ($request->filled('search')) {
@@ -49,6 +71,8 @@ class EstanteriaController extends Controller
 
         return Inertia::render('Estanteria/index', [
             'estanterias' => $estanterias,
+            'all_secciones' => $allSecciones,
+            'seccionId' => $seccionId,
             'flash' => [
                 'success' => session('success'),
                 'error' => session('error'),
@@ -69,9 +93,26 @@ class EstanteriaController extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create()
+    public function create(Request $request)
     {
+        // Obtener la sección del usuario según su rol
+        $user = $request->user();
+        $seccionId = null;
+        
+        if ($user->hasRole('BibliotecarioPrimaria')) {
+            $seccion = Seccion::where('nombre', 'PRIMARIA')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+        } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+            $seccion = Seccion::where('nombre', 'BACHILLERATO')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+        }
+        
+        // Obtener todas las secciones para el formulario
+        $allSecciones = Seccion::all();
+        
         return Inertia::render('Estanteria/Create', [
+            'all_secciones' => $allSecciones,
+            'seccionId' => $seccionId,
             'errors' => session('errors') ? session('errors')->getBag('default')->getMessages() : (object) [],
         ]);
     }
@@ -84,7 +125,24 @@ class EstanteriaController extends Controller
         $validated = $request->validate([
             'cod_estante' => 'required|string|max:10|unique:estanterias',
             'descripcion' => 'nullable|string|max:255',
+            'seccion_id' => 'required|exists:secciones,id',
         ]);
+        
+        // Verificar que el usuario tenga permisos para crear en esta sección
+        $user = $request->user();
+        $seccionNombre = Seccion::find($validated['seccion_id'])->nombre;
+        
+        if ($user->hasRole('BibliotecarioPrimaria') && $seccionNombre !== 'PRIMARIA') {
+            return redirect()->back()
+                ->withErrors(['seccion_id' => 'No tienes permisos para crear estanterías en esta sección.'])
+                ->withInput();
+        }
+        
+        if ($user->hasRole('BibliotecarioBachillerato') && $seccionNombre !== 'BACHILLERATO') {
+            return redirect()->back()
+                ->withErrors(['seccion_id' => 'No tienes permisos para crear estanterías en esta sección.'])
+                ->withInput();
+        }
         
         Estanteria::create($validated);
         
@@ -97,6 +155,9 @@ class EstanteriaController extends Controller
      */
     public function show(Estanteria $estanteria)
     {
+        // Cargar la relación con sección
+        $estanteria->load('seccion');
+        
         return Inertia::render('Estanteria/Show', [
             'estanteria' => $estanteria,
         ]);
@@ -105,10 +166,30 @@ class EstanteriaController extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(Estanteria $estanteria)
+    public function edit(Request $request, Estanteria $estanteria)
     {
+        // Cargar la relación con sección
+        $estanteria->load('seccion');
+        
+        // Obtener la sección del usuario según su rol
+        $user = $request->user();
+        $seccionId = null;
+        
+        if ($user->hasRole('BibliotecarioPrimaria')) {
+            $seccion = Seccion::where('nombre', 'PRIMARIA')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+        } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+            $seccion = Seccion::where('nombre', 'BACHILLERATO')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+        }
+        
+        // Obtener todas las secciones para el formulario
+        $allSecciones = Seccion::all();
+        
         return Inertia::render('Estanteria/Edit', [
             'estanteria' => $estanteria,
+            'all_secciones' => $allSecciones,
+            'seccionId' => $seccionId,
             'errors' => session('errors') ? session('errors')->getBag('default')->getMessages() : (object) [],
         ]);
     }
@@ -121,7 +202,24 @@ class EstanteriaController extends Controller
         $validated = $request->validate([
             'cod_estante' => 'required|string|max:10|unique:estanterias,cod_estante,'.$estanteria->id,
             'descripcion' => 'nullable|string|max:255',
+            'seccion_id' => 'required|exists:secciones,id',
         ]);
+        
+        // Verificar que el usuario tenga permisos para editar en esta sección
+        $user = $request->user();
+        $seccionNombre = Seccion::find($validated['seccion_id'])->nombre;
+        
+        if ($user->hasRole('BibliotecarioPrimaria') && $seccionNombre !== 'PRIMARIA') {
+            return redirect()->back()
+                ->withErrors(['seccion_id' => 'No tienes permisos para editar estanterías en esta sección.'])
+                ->withInput();
+        }
+        
+        if ($user->hasRole('BibliotecarioBachillerato') && $seccionNombre !== 'BACHILLERATO') {
+            return redirect()->back()
+                ->withErrors(['seccion_id' => 'No tienes permisos para editar estanterías en esta sección.'])
+                ->withInput();
+        }
         
         $estanteria->update($validated);
         

--- a/app/Http/Controllers/GradoController.php
+++ b/app/Http/Controllers/GradoController.php
@@ -39,6 +39,21 @@ public function index(Request $request): Response|RedirectResponse
 
     // Query base - INCLUIR LA RELACIÓN CON SECCIÓN
     $query = Grado::with('seccion'); // Esta es la línea clave que faltaba
+    
+    // Filtrar por sección según el rol del usuario
+    $user = request()->user();
+    if ($user->hasRole('BibliotecarioPrimaria')) {
+        $seccion = \App\Models\Seccion::where('nombre', 'PRIMARIA')->first();
+        if ($seccion) {
+            $query->where('seccion_id', $seccion->id);
+        }
+    } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+        $seccion = \App\Models\Seccion::where('nombre', 'BACHILLERATO')->first();
+        if ($seccion) {
+            $query->where('seccion_id', $seccion->id);
+        }
+    }
+    // Los administradores pueden ver todos los grados
 
     // Aplicar filtro de búsqueda si existe
     if (!empty($search)) {
@@ -178,6 +193,17 @@ public function index(Request $request): Response|RedirectResponse
 
     // Obtener todas las secciones para el filtro
     $allSecciones = \App\Models\Seccion::orderBy('nombre')->get();
+    
+    // Determinar la sección predeterminada según el rol del usuario para el componente Create
+    $seccionId = null;
+    $user = request()->user();
+    if ($user->hasRole('BibliotecarioPrimaria')) {
+        $seccion = \App\Models\Seccion::where('nombre', 'PRIMARIA')->first();
+        $seccionId = $seccion ? $seccion->id : null;
+    } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+        $seccion = \App\Models\Seccion::where('nombre', 'BACHILLERATO')->first();
+        $seccionId = $seccion ? $seccion->id : null;
+    }
 
     return Inertia::render('Grado/Index', [
         'grados' => $grados,
@@ -188,6 +214,7 @@ public function index(Request $request): Response|RedirectResponse
         'all_grados' => $allGrados,
         'all_estados' => $allEstados,
         'all_secciones' => $allSecciones, // Agregar secciones para el filtro
+        'seccionId' => $seccionId, // Pasar la sección predeterminada según el rol
         'pagination' => [
             'current_page' => $grados->currentPage(),
             'last_page' => $grados->lastPage(),
@@ -205,7 +232,24 @@ public function index(Request $request): Response|RedirectResponse
      */
     public function create(): Response
     {
-        return Inertia::render('Grado/Create');
+        // Obtener todas las secciones disponibles
+        $secciones = \App\Models\Seccion::orderBy('nombre')->get();
+        
+        // Determinar la sección predeterminada según el rol del usuario
+        $seccionId = null;
+        $user = request()->user();
+        if ($user->hasRole('BibliotecarioPrimaria')) {
+            $seccion = \App\Models\Seccion::where('nombre', 'PRIMARIA')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+        } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+            $seccion = \App\Models\Seccion::where('nombre', 'BACHILLERATO')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+        }
+        
+        return Inertia::render('Grado/Create', [
+            'secciones' => $secciones,
+            'seccionId' => $seccionId // Pasar la sección predeterminada según el rol
+        ]);
     }
 
     /**
@@ -226,6 +270,20 @@ public function index(Request $request): Response|RedirectResponse
                 'estado' => ['required', 'string', Rule::in(['ACTIVO', 'INACTIVO'])],
                 'seccion_id' => 'required|exists:secciones,id'
             ]);
+            
+            // Validar que el usuario solo pueda actualizar grados en su sección asignada
+             $user = request()->user();
+             if ($user->hasRole('BibliotecarioPrimaria')) {
+                 $seccion = \App\Models\Seccion::where('nombre', 'PRIMARIA')->first();
+                 if ($seccion && $validated['seccion_id'] != $seccion->id) {
+                     return redirect()->back()->withErrors(['seccion_id' => 'Como bibliotecario de primaria, solo puede actualizar grados para la sección PRIMARIA.']);
+                 }
+             } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+                 $seccion = \App\Models\Seccion::where('nombre', 'BACHILLERATO')->first();
+                 if ($seccion && $validated['seccion_id'] != $seccion->id) {
+                     return redirect()->back()->withErrors(['seccion_id' => 'Como bibliotecario de bachillerato, solo puede actualizar grados para la sección BACHILLERATO.']);
+                 }
+             }
 
             DB::beginTransaction();
             $grado = Grado::create($validated);
@@ -276,12 +334,30 @@ public function index(Request $request): Response|RedirectResponse
     }
 
     /**
-     * Muestra el formulario para editar un grado existente.
+     * Muestra el formulario para editar el grado especificado.
      */
     public function edit(Grado $grado): Response
     {
+        // Validar que el usuario pueda editar este grado según su rol
+        $user = request()->user();
+        if ($user->hasRole('BibliotecarioPrimaria')) {
+            $seccion = \App\Models\Seccion::where('nombre', 'PRIMARIA')->first();
+            if ($seccion && $grado->seccion_id != $seccion->id) {
+                abort(403, 'No tiene permisos para editar grados de esta sección.');
+            }
+        } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+            $seccion = \App\Models\Seccion::where('nombre', 'BACHILLERATO')->first();
+            if ($seccion && $grado->seccion_id != $seccion->id) {
+                abort(403, 'No tiene permisos para editar grados de esta sección.');
+            }
+        }
+        
+        // Obtener todas las secciones disponibles
+        $secciones = \App\Models\Seccion::orderBy('nombre')->get();
+        
         return Inertia::render('Grado/Edit', [
-            'grado' => $grado->fresh()
+            'grado' => $grado->load('seccion'),
+            'secciones' => $secciones
         ]);
     }
 
@@ -381,5 +457,37 @@ public function update(Request $request, Grado $grado): RedirectResponse
             ->withInput();
     }
 }
+
+    /**
+     * Elimina el grado especificado del almacenamiento.
+     */
+    public function destroy(Grado $grado): RedirectResponse
+    {
+        try {
+            // Validar que el usuario pueda eliminar este grado según su rol
+            $user = request()->user();
+            if ($user->hasRole('BibliotecarioPrimaria')) {
+                $seccion = \App\Models\Seccion::where('nombre', 'PRIMARIA')->first();
+                if ($seccion && $grado->seccion_id != $seccion->id) {
+                    return redirect()->route('grados.index')
+                        ->with('error', 'No tiene permisos para eliminar grados de esta sección.');
+                }
+            } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+                $seccion = \App\Models\Seccion::where('nombre', 'BACHILLERATO')->first();
+                if ($seccion && $grado->seccion_id != $seccion->id) {
+                    return redirect()->route('grados.index')
+                        ->with('error', 'No tiene permisos para eliminar grados de esta sección.');
+                }
+            }
+            
+            $grado->delete();
+            return redirect()->route('grados.index')
+                ->with('success', 'Grado eliminado exitosamente.');
+        } catch (\Exception $e) {
+            Log::error('Error al eliminar grado: ' . $e->getMessage());
+            return redirect()->route('grados.index')
+                ->with('error', 'Error al eliminar el grado.');
+        }
+    }
 
 }

--- a/app/Http/Controllers/LibroController.php
+++ b/app/Http/Controllers/LibroController.php
@@ -34,7 +34,7 @@ class LibroController extends Controller
                 ]
             ]);
         }
-        
+
         $libro = Libro::with([
             'autor',
             'editorial',
@@ -71,23 +71,43 @@ class LibroController extends Controller
     {
         // Validación de parámetros de paginación (igual que AutorController)
         $page = max(1, (int) $request->input('page', 1));
-        $perPage = 15; // Valor fijo de 20 elementos por página
+        $perPage = 15; // Valor fijo de 15 elementos por página
 
         // Query base con relaciones necesarias
         $query = Libro::with(['autor', 'editorial', 'seccion', 'temaDewey', 'estanteria'])
-            ->select(['libros.*', 
-                     \DB::raw("(SELECT COUNT(*) FROM ejemplares WHERE ejemplares.libro_id = libros.id AND ejemplares.estado = 'DISPONIBLE') as ejemplares_count")]);    
+            ->select([
+                'libros.*',
+                DB::raw("(SELECT COUNT(*) FROM ejemplares WHERE ejemplares.libro_id = libros.id AND ejemplares.estado = 'DISPONIBLE') as ejemplares_count")
+            ]);
+
+        // Filtrar por sección según el rol del usuario
+        $user = $request->user();
+        $seccionId = null;
+        
+        if ($user->hasRole('BibliotecarioPrimaria')) {
+            $seccion = Seccion::where('nombre', 'PRIMARIA')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+            if ($seccionId) {
+                $query->where('seccion_id', $seccionId);
+            }
+        } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+            $seccion = Seccion::where('nombre', 'BACHILLERATO')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+            if ($seccionId) {
+                $query->where('seccion_id', $seccionId);
+            }
+        }
 
         // Aplicar filtros en el backend (mucho más eficiente)
         if ($request->filled('search')) {
             $searchTerm = $request->search;
-            $query->where(function($q) use ($searchTerm) {
+            $query->where(function ($q) use ($searchTerm) {
                 $q->where('titulo', 'like', '%' . $searchTerm . '%')
-                  ->orWhere('isbn', 'like', '%' . $searchTerm . '%')
-                  ->orWhereHas('autor', function($authorQuery) use ($searchTerm) {
-                      $authorQuery->where('nombres', 'like', '%' . $searchTerm . '%')
-                                  ->orWhere('apellidos', 'like', '%' . $searchTerm . '%');
-                  });
+                    ->orWhere('isbn', 'like', '%' . $searchTerm . '%')
+                    ->orWhereHas('autor', function ($authorQuery) use ($searchTerm) {
+                        $authorQuery->where('nombres', 'like', '%' . $searchTerm . '%')
+                            ->orWhere('apellidos', 'like', '%' . $searchTerm . '%');
+                    });
             });
         }
 
@@ -105,12 +125,13 @@ class LibroController extends Controller
 
         // Paginación optimizada con parámetros explícitos (igual que AutorController)
         $libros = $query->orderBy('id')
-                       ->paginate($perPage, ['*'], 'page', $page)
-                       ->withQueryString(); // Mantiene los filtros en la URL
+            ->paginate($perPage, ['*'], 'page', $page)
+            ->withQueryString(); // Mantiene los filtros en la URL
 
         // Redirigir si la página solicitada no existe pero hay resultados (igual que AutorController)
         if ($page > $libros->lastPage() && $libros->lastPage() > 0) {
-            return redirect()->route('libros.index', 
+            return redirect()->route(
+                'libros.index',
                 array_merge($request->query(), ['page' => $libros->lastPage()])
             );
         }
@@ -135,20 +156,20 @@ class LibroController extends Controller
 
         // Solo cargar datos de filtros cuando son necesarios
         $autores = Autor::select(['id', 'nombres', 'apellidos'])
-                        ->orderBy('apellidos')
-                        ->get();
-                        
+            ->orderBy('apellidos')
+            ->get();
+
         $estanterias = Estanteria::select(['id', 'cod_estante'])
-                                ->orderBy('cod_estante')
-                                ->get();
-                                
+            ->orderBy('cod_estante')
+            ->get();
+
         $secciones = Seccion::select(['id', 'nombre'])
-                           ->orderBy('nombre')
-                           ->get();
-                           
+            ->orderBy('nombre')
+            ->get();
+
         $categoriasDewey = CategoriaDewey::select(['id', 'nombre', 'codigo'])
-                                       ->orderBy('codigo')
-                                       ->get();
+            ->orderBy('codigo')
+            ->get();
 
         return Inertia::render('Libro/index', [
             'libros' => $libros, // Objeto paginado de Laravel
@@ -158,6 +179,7 @@ class LibroController extends Controller
             'estanterias' => $estanterias,
             'secciones' => $secciones,
             'categoriasDewey' => $categoriasDewey,
+            'seccionId' => $seccionId,
             'filters' => $request->only(['search', 'clase', 'idioma', 'estanteria']),
             // Datos de paginación adicionales (igual que AutorController)
             'pagination' => [
@@ -177,10 +199,28 @@ class LibroController extends Controller
      */
     public function create()
     {
+        // Obtener el usuario autenticado
+        $user = request()->user();
+        $seccionId = null;
+
+        // Asignar sección según el rol del usuario
+        if ($user->hasRole('BibliotecarioPrimaria')) {
+            $seccion = Seccion::where('nombre', 'PRIMARIA')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+        } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+            $seccion = Seccion::where('nombre', 'BACHILLERATO')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+        }
+
         // Utilizando apellidos (plural)
         $autores = Autor::orderBy('apellidos')->get();
         $editoriales = Editorial::orderBy('nombre')->get();
-        $estanterias = Estanteria::all();
+        
+        // Filtrar estanterías según la sección del usuario
+        $estanterias = $seccionId 
+            ? Estanteria::where('seccion_id', $seccionId)->get()
+            : Estanteria::all();
+            
         $secciones = Seccion::all();
         $categoriasDewey = CategoriaDewey::all();
 
@@ -208,7 +248,8 @@ class LibroController extends Controller
             'secciones' => $secciones,
             'categoriasDewey' => $categoriasDewey,
             'clases' => $clases,
-            'idiomas' => $idiomas
+            'idiomas' => $idiomas,
+            'seccionId' => $seccionId // Pasar la sección predeterminada según el rol
         ]);
     }
 
@@ -223,12 +264,32 @@ class LibroController extends Controller
         if ($request->has('estanteria_id') && $request->estanteria_id === '') {
             $request->merge(['estanteria_id' => null]);
         }
-        
+
         // Debug adicional
         Log::info('Después de procesar estanteria_id:', [
             'estanteria_id' => $request->estanteria_id,
             'type' => gettype($request->estanteria_id)
         ]);
+
+        // Validar que la sección corresponda al rol del usuario
+        $user = request()->user();
+        $seccionId = null;
+
+        if ($user->hasRole('BibliotecarioPrimaria')) {
+            $seccion = Seccion::where('nombre', 'PRIMARIA')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+
+            if ($seccionId && $request->seccion_id != $seccionId) {
+                return redirect()->back()->withErrors(['seccion_id' => 'Como bibliotecario de primaria, solo puede crear libros para la sección PRIMARIA.']);
+            }
+        } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+            $seccion = Seccion::where('nombre', 'BACHILLERATO')->first();
+            $seccionId = $seccion ? $seccion->id : null;
+
+            if ($seccionId && $request->seccion_id != $seccionId) {
+                return redirect()->back()->withErrors(['seccion_id' => 'Como bibliotecario de bachillerato, solo puede crear libros para la sección BACHILLERATO.']);
+            }
+        }
 
         $validator = Validator::make($request->all(), [
             'estanteria_id' => 'nullable|exists:estanterias,id',
@@ -255,7 +316,7 @@ class LibroController extends Controller
             'paginas' => 'nullable|integer|min:1',
             'tema_id' => 'required|exists:temas_dewey,id',
             // CORREGIDO: nullable debe ir antes de exists
-            'estanteria_id' => 'nullable|exists:estanterias,id',
+            // Removed duplicate estanteria_id validation rule since it was already defined above
             'tomo' => 'nullable|integer|min:1',
             'edicion' => 'nullable|string|max:50',
             'anio' => 'nullable|integer|min:1000|max:' . (date('Y') + 1),
@@ -339,7 +400,7 @@ class LibroController extends Controller
             $libro->paginas = $request->paginas ?: 1;
             $libro->tema_id = $request->tema_id;
             $libro->sign_top = $signTop;
-            
+
             // NUEVA LÓGICA: Manejo mejorado de estantería
             $libro->estanteria_id = $request->estanteria_id; // Ya es null si no se proporcionó
 
@@ -357,21 +418,20 @@ class LibroController extends Controller
             DB::commit();
 
             Log::info('Libro y ejemplar creados exitosamente:', [
-                'libro_id' => $libro->id, 
+                'libro_id' => $libro->id,
                 'titulo' => $libro->titulo,
                 'ejemplar_id' => $ejemplar->id
             ]);
 
             return redirect()->route('libros.index')
                 ->with('success', 'El libro "' . $libro->titulo . '" ha sido registrado correctamente con su primer ejemplar.');
-
         } catch (\Exception $e) {
             DB::rollBack();
             Log::error('Error al crear libro:', [
                 'error' => $e->getMessage(),
                 'request_data' => $request->all()
             ]);
-            
+
             return redirect()->back()
                 ->with('error', 'Error al crear el libro: ' . $e->getMessage())
                 ->withInput();
@@ -414,10 +474,39 @@ class LibroController extends Controller
             'estanteria'
         ])->findOrFail($id);
 
+        // Validar que el usuario tenga permiso para editar este libro según su sección
+        if (request()->user()->hasRole('BibliotecarioPrimaria') && $libro->seccion_id != 1) {
+            return redirect()->route('libros.index')
+                ->with('error', 'Como Bibliotecario de Primaria, solo puede editar libros de la sección de Primaria.');
+        }
+
+        if (request()->user()->hasRole('BibliotecarioBachillerato') && $libro->seccion_id != 2) {
+            return redirect()->route('libros.index')
+                ->with('error', 'Como Bibliotecario de Bachillerato, solo puede editar libros de la sección de Bachillerato.');
+        }
+
+        // Obtener el usuario autenticado para filtrar estanterías
+        $user = request()->user();
+        $userSeccionId = null;
+
+        // Determinar la sección del usuario
+        if ($user->hasRole('BibliotecarioPrimaria')) {
+            $seccion = Seccion::where('nombre', 'PRIMARIA')->first();
+            $userSeccionId = $seccion ? $seccion->id : null;
+        } elseif ($user->hasRole('BibliotecarioBachillerato')) {
+            $seccion = Seccion::where('nombre', 'BACHILLERATO')->first();
+            $userSeccionId = $seccion ? $seccion->id : null;
+        }
+
         // Datos para el formulario - usando apellidos (plural)
         $autores = Autor::orderBy('apellidos')->get();
         $editoriales = Editorial::orderBy('nombre')->get();
-        $estanterias = Estanteria::all();
+        
+        // Filtrar estanterías según la sección del usuario
+        $estanterias = $userSeccionId 
+            ? Estanteria::where('seccion_id', $userSeccionId)->get()
+            : Estanteria::all();
+            
         $secciones = Seccion::all();
         $categoriasDewey = CategoriaDewey::orderBy('codigo')->get();
 
@@ -431,7 +520,7 @@ class LibroController extends Controller
             $subcategoriasDewey = SubcategoriaDewey::where('categoria_id', $libro->temaDewey->subcategoria->categoria_id)
                 ->orderBy('codigo')
                 ->get();
-            
+
             // Cargar todos los temas de la subcategoría actual
             $temasDewey = TemaDewey::where('subcategoria_id', $libro->temaDewey->subcategoria_id)
                 ->orderBy('codigo')
@@ -455,6 +544,14 @@ class LibroController extends Controller
             Libro::IDIOMA_OTRO,
         ];
 
+        // Determinar la sección según el rol del usuario para la interfaz
+        $seccionId = null;
+        if (request()->user()->hasRole('BibliotecarioPrimaria')) {
+            $seccionId = 1; // ID de la sección Primaria
+        } elseif (request()->user()->hasRole('BibliotecarioBachillerato')) {
+            $seccionId = 2; // ID de la sección Bachillerato
+        }
+
         return Inertia::render('Libro/Edit', [
             'libro' => $libro,
             'autores' => $autores,
@@ -465,7 +562,8 @@ class LibroController extends Controller
             'subcategoriasDewey' => $subcategoriasDewey,
             'temasDewey' => $temasDewey,
             'clases' => $clases,
-            'idiomas' => $idiomas
+            'idiomas' => $idiomas,
+            'seccionId' => $seccionId
         ]);
     }
 
@@ -482,6 +580,19 @@ class LibroController extends Controller
         // NUEVA LÓGICA: Procesar estanteria_id antes de la validación
         if ($request->has('estanteria_id') && $request->estanteria_id === '') {
             $request->merge(['estanteria_id' => null]);
+        }
+
+        // Validar que la sección coincida con el rol del usuario
+        if (request()->user()->hasRole('BibliotecarioPrimaria') && $request->seccion_id != 1) {
+            return redirect()->back()
+                ->with('error', 'Como Bibliotecario de Primaria, solo puede editar libros de la sección de Primaria.')
+                ->withInput();
+        }
+
+        if (request()->user()->hasRole('BibliotecarioBachillerato') && $request->seccion_id != 2) {
+            return redirect()->back()
+                ->with('error', 'Como Bibliotecario de Bachillerato, solo puede editar libros de la sección de Bachillerato.')
+                ->withInput();
         }
 
         $validator = Validator::make($request->all(), [
@@ -603,16 +714,15 @@ class LibroController extends Controller
             // Redirigir con mensaje de éxito
             return redirect()->route('libros.index')
                 ->with('success', 'El libro "' . $libro->titulo . '" ha sido modificado correctamente.');
-
         } catch (\Exception $e) {
             DB::rollBack();
-            
+
             Log::error('Error al actualizar libro:', [
                 'error' => $e->getMessage(),
                 'libro_id' => $id,
                 'request_data' => $request->all()
             ]);
-            
+
             return redirect()->back()
                 ->withInput()
                 ->with('error', 'Error al actualizar el libro: ' . $e->getMessage());

--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CheckRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  $role
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next, ...$roles)
+    {
+        if (!Auth::check()) {
+            return redirect('login');
+        }
+
+        $user = Auth::user();
+
+        foreach ($roles as $role) {
+            if ($user->hasRole($role)) {
+                return $next($request);
+            }
+        }
+        // Si no tiene permisos, devolver error 403
+        if ($request->expectsJson()) {
+            return response()->json(['message' => 'No tienes permiso para acceder a esta página.'], 403);
+        }
+        abort(403, 'No tienes permiso para acceder a esta página.');
+    }
+}

--- a/app/Models/Estanteria.php
+++ b/app/Models/Estanteria.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Estanteria extends Model
 {
@@ -14,12 +15,25 @@ class Estanteria extends Model
 
     protected $fillable = [
         'cod_estante',
-        'descripcion'
+        'descripcion',
+        'seccion_id'
     ];
 
     // Relación con libros: una estantería puede tener muchos libros
     public function libros(): HasMany
     {
         return $this->hasMany(Libro::class);
+    }
+
+    // Relación con sección: una estantería pertenece a una sección
+    public function seccion(): BelongsTo
+    {
+        return $this->belongsTo(Seccion::class);
+    }
+
+    // Scope para filtrar por sección
+    public function scopePorSeccion($query, $seccionId)
+    {
+        return $query->where('seccion_id', $seccionId);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,6 +22,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'seccion_id',
     ];
 
     /**
@@ -45,5 +46,13 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+    
+    /**
+     * Obtiene la sección asignada al usuario (para bibliotecarios)
+     */
+    public function seccion()
+    {
+        return $this->belongsTo(Seccion::class);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\CheckRole;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -9,8 +10,8 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
-        commands: __DIR__.'/../routes/console.php',
+        web: __DIR__ . '/../routes/web.php',
+        commands: __DIR__ . '/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
@@ -20,6 +21,16 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleAppearance::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
+        ]);
+
+        $middleware->web([
+            Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+        ]);
+
+
+        // Registrar el middleware de roles
+        $middleware->alias([
+            'role' => CheckRole::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/database/migrations/2025_08_15_153415_add_seccion_id_to_estanterias_table.php
+++ b/database/migrations/2025_08_15_153415_add_seccion_id_to_estanterias_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('estanterias', function (Blueprint $table) {
+            $table->unsignedBigInteger('seccion_id')->nullable()->after('descripcion');
+            $table->foreign('seccion_id')->references('id')->on('secciones')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('estanterias', function (Blueprint $table) {
+            $table->dropForeign(['seccion_id']);
+            $table->dropColumn('seccion_id');
+        });
+    }
+};

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -17,8 +17,12 @@ class RolesSeeder extends Seeder
             Role::create(['name' => 'Administrador']);
         }
 
-        if (!Role::where('name', 'Bibliotecario')->exists()) {
-            Role::create(['name' => 'Bibliotecario']);
+        if (!Role::where('name', 'BibliotecarioPrimaria')->exists()) {
+            Role::create(['name' => 'BibliotecarioPrimaria']);
+        }
+
+        if (!Role::where('name', 'BibliotecarioBachillerato')->exists()) {
+            Role::create(['name' => 'BibliotecarioBachillerato']);
         }
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -5,30 +5,54 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\DB;
+use App\Models\User;
+use App\Models\Seccion;
+use Spatie\Permission\Models\Role;
 
 class UserSeeder extends Seeder
 {
     public function run(): void
     {
-        DB::table('users')->insert([
-            [
-                'name' => 'Primaria',
-                'email' => 'primaria@gmail.com',
-                'email_verified_at' => now(),
-                'password' => Hash::make('primaria'),
-                'seccion_id' => null,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'name' => 'Bachillerato',
-                'email' => 'bachillerato@gmail.com',
-                'email_verified_at' => now(),
-                'password' => Hash::make('bachillerato'),
-                'seccion_id' => null,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
+        // Obtener las secciones
+        $seccionPrimaria = Seccion::where('nombre', 'PRIMARIA')->first();
+        $seccionBachillerato = Seccion::where('nombre', 'BACHILLERATO')->first();
+        
+        // Crear usuario administrador
+        $admin = User::create([
+            'name' => 'Administrador',
+            'email' => 'admin@gmail.com',
+            'email_verified_at' => now(),
+            'password' => Hash::make('admin123'),
+            'seccion_id' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
         ]);
+        
+        // Crear usuario de primaria
+        $primaria = User::create([
+            'name' => 'Primaria',
+            'email' => 'primaria@gmail.com',
+            'email_verified_at' => now(),
+            'password' => Hash::make('primaria'),
+            'seccion_id' => $seccionPrimaria ? $seccionPrimaria->id : null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        
+        // Crear usuario de bachillerato
+        $bachillerato = User::create([
+            'name' => 'Bachillerato',
+            'email' => 'bachillerato@gmail.com',
+            'email_verified_at' => now(),
+            'password' => Hash::make('bachillerato'),
+            'seccion_id' => $seccionBachillerato ? $seccionBachillerato->id : null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        
+        // Asignar roles a los usuarios
+        $admin->assignRole('Administrador');
+        $primaria->assignRole('BibliotecarioPrimaria');
+        $bachillerato->assignRole('BibliotecarioBachillerato');
     }
 }

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -19,15 +19,56 @@ window.axios.interceptors.request.use((config) => {
     return config;
 });
 
-// Interceptor para responses - maneja errores 419 automáticamente
+// Función para refrescar el token CSRF sin recargar la página
+const refreshCsrfToken = async () => {
+    try {
+        // Solicitar un nuevo token CSRF
+        const response = await fetch('/csrf-refresh', {
+            method: 'GET',
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            credentials: 'same-origin'
+        });
+        
+        if (response.ok) {
+            const data = await response.json();
+            // Actualizar el token en el DOM
+            const metaTag = document.head.querySelector('meta[name="csrf-token"]');
+            if (metaTag && data.token) {
+                metaTag.setAttribute('content', data.token);
+                return true;
+            }
+        }
+        return false;
+    } catch (error) {
+        console.error('Error al refrescar el token CSRF:', error);
+        return false;
+    }
+};
+
+// Interceptor para responses - maneja errores 419 con refresco de token
 window.axios.interceptors.response.use(
     (response) => response,
-    (error) => {
+    async (error) => {
         if (error.response?.status === 419) {
-            console.log('🔄 Token CSRF expirado - refrescando página automáticamente...');
-            // Mostrar notificación opcional antes de recargar
-            // alert('La sesión ha expirado. La página se recargará automáticamente.');
-            window.location.reload();
+            console.log('🔄 Token CSRF expirado - intentando refrescar token...');
+            
+            // Intentar refrescar el token
+            const refreshed = await refreshCsrfToken();
+            
+            if (refreshed) {
+                // Si se refrescó correctamente, reintentar la solicitud original
+                console.log('✅ Token CSRF actualizado, reintentando solicitud...');
+                const originalRequest = error.config;
+                // Actualizar el token en la solicitud original
+                originalRequest.headers['X-CSRF-TOKEN'] = getCsrfToken();
+                return axios(originalRequest);
+            } else {
+                // Si no se pudo refrescar, recargar la página como último recurso
+                console.log('❌ No se pudo refrescar el token, recargando página...');
+                window.location.reload();
+            }
         }
         return Promise.reject(error);
     }

--- a/resources/js/pages/Estanteria/Create.tsx
+++ b/resources/js/pages/Estanteria/Create.tsx
@@ -8,19 +8,22 @@ type CreateModalProps = {
   onSuccess: (message: string) => void;
   onError: (message: string) => void;
   errors?: Record<string, string>;
+  all_secciones?: Array<{ id: number; nombre: string }>;
+  seccionId?: number | null;
 };
 
-export default function CreateEstanteria({ onSuccess, onError, errors = {} }: CreateModalProps) {
+export default function CreateEstanteria({ onSuccess, onError, errors = {}, all_secciones = [], seccionId = null }: CreateModalProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const { data, setData, post, processing, reset, errors: formErrors, setError, clearErrors } = useForm({
     cod_estante: '',
-    descripcion: ''
+    descripcion: '',
+    seccion_id: seccionId || ''
   });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
-    const validFields: Array<keyof typeof data> = ['cod_estante', 'descripcion'];
+    const validFields: Array<keyof typeof data> = ['cod_estante', 'descripcion', 'seccion_id'];
     if (validFields.includes(name as keyof typeof data)) {
       setData(name as keyof typeof data, value);
       console.log('Form data updated - Current state:', { ...data, [name]: value });
@@ -53,7 +56,7 @@ export default function CreateEstanteria({ onSuccess, onError, errors = {} }: Cr
       },
       onError: (errors: Record<string, string>) => {
         console.log('Error response:', errors);
-        const hasFieldErrors = Object.keys(errors).some(key => ['cod_estante', 'descripcion'].includes(key));
+        const hasFieldErrors = Object.keys(errors).some(key => ['cod_estante', 'descripcion', 'seccion_id'].includes(key));
         if (hasFieldErrors) {
           Object.keys(errors).forEach((key) => {
             setError(key as keyof typeof data, errors[key]);
@@ -101,6 +104,19 @@ export default function CreateEstanteria({ onSuccess, onError, errors = {} }: Cr
       onChange: handleChange,
       rows: 4,
       className: 'resize-y min-h-[100px] max-h-[300px]'
+    },
+    {
+      name: 'seccion_id',
+      label: 'Sección',
+      type: 'select',
+      required: true,
+      value: data.seccion_id,
+      onChange: handleChange,
+      disabled: seccionId !== null,
+      options: all_secciones.map(seccion => ({
+        value: seccion.id.toString(),
+        label: seccion.nombre
+      }))
     }
   ];
 
@@ -155,7 +171,7 @@ export default function CreateEstanteria({ onSuccess, onError, errors = {} }: Cr
         <div onKeyDown={handleKeyPress}>
           <Form
             initialData={data}
-            fields={estanteriaFields}
+            fields={estanteriaFields as any[]}
             errors={formErrors}
             submitUrl="/estanterias"
             method="post"

--- a/resources/js/pages/Estanteria/Edit.tsx
+++ b/resources/js/pages/Estanteria/Edit.tsx
@@ -10,11 +10,14 @@ type EditModalProps = {
   onSuccess: (message: string) => void;
   onError: (message: string) => void;
   errors?: Record<string, string>;
+  all_secciones?: Array<{ id: number; nombre: string }>;
+  seccionId?: number | null;
 };
 
 type FormData = {
   cod_estante: string;
   descripcion: string;
+  seccion_id: number;
 };
 
 type FormField = {
@@ -32,19 +35,21 @@ type FormField = {
   className?: string;
 };
 
-export default function EditEstanteria({ estanteria, onSuccess, onError, errors = {} }: EditModalProps) {
+export default function EditEstanteria({ estanteria, onSuccess, onError, errors = {}, all_secciones = [], seccionId = null }: EditModalProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const { data, setData, put, processing, errors: formErrors, setError, clearErrors, reset } = useForm<FormData>({
     cod_estante: estanteria.cod_estante || '',
-    descripcion: estanteria.descripcion || ''
+    descripcion: estanteria.descripcion || '',
+    seccion_id: estanteria.seccion_id || 0
   });
 
   // Sync form data with updated estanteria prop
   useEffect(() => {
     setData({
       cod_estante: estanteria.cod_estante || '',
-      descripcion: estanteria.descripcion || ''
+      descripcion: estanteria.descripcion || '',
+      seccion_id: estanteria.seccion_id || 0
     });
     clearErrors();
   }, [estanteria, setData, clearErrors]);
@@ -52,8 +57,8 @@ export default function EditEstanteria({ estanteria, onSuccess, onError, errors 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     
-    if (name === 'cod_estante' || name === 'descripcion') {
-      setData(name, value);
+    if (name === 'cod_estante' || name === 'descripcion' || name === 'seccion_id') {
+      setData(name as keyof FormData, name === 'seccion_id' ? parseInt(value) : value);
       console.log('Form data updated - Current state:', { ...data, [name]: value });
     } else {
       console.error('Invalid field name:', name);
@@ -92,6 +97,19 @@ export default function EditEstanteria({ estanteria, onSuccess, onError, errors 
       onChange: handleChange,
       rows: 4,
       className: 'resize-y min-h-[100px] max-h-[300px]'
+    },
+    {
+      name: 'seccion_id',
+      label: 'Sección',
+      type: 'select',
+      required: true,
+      value: data.seccion_id.toString(),
+      onChange: handleChange,
+      disabled: seccionId !== null,
+      options: all_secciones.map(seccion => ({
+        value: seccion.id.toString(),
+        label: seccion.nombre
+      }))
     }
   ];
 
@@ -117,7 +135,8 @@ export default function EditEstanteria({ estanteria, onSuccess, onError, errors 
         // Reset form with updated estanteria data
         setData({
           cod_estante: estanteria.cod_estante || '',
-          descripcion: estanteria.descripcion || ''
+          descripcion: estanteria.descripcion || '',
+          seccion_id: estanteria.seccion_id || 0
         });
         clearErrors();
         setIsOpen(false);
@@ -130,8 +149,11 @@ export default function EditEstanteria({ estanteria, onSuccess, onError, errors 
         if (errors.descripcion) {
           setError('descripcion', errors.descripcion);
         }
+        if (errors.seccion_id) {
+          setError('seccion_id', errors.seccion_id);
+        }
         
-        if (!errors.cod_estante && !errors.descripcion && errors.error) {
+        if (!errors.cod_estante && !errors.descripcion && !errors.seccion_id && errors.error) {
           const errorMessage = errors.error || 'Ha ocurrido un error al actualizar la estantería';
           onError(errorMessage);
         }

--- a/resources/js/pages/Estanteria/Show.tsx
+++ b/resources/js/pages/Estanteria/Show.tsx
@@ -36,6 +36,16 @@ export default function ShowEstanteria({ estanteria }: ShowModalProps) {
                 {estanteria.cod_estante}
               </dd>
             </div>
+            <div className="sm:col-span-1">
+              <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-2">
+                Sección
+              </dt>
+              <dd className="text-base text-gray-900 dark:text-white font-medium">
+                <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                  {estanteria.seccion?.nombre || 'Sin sección'}
+                </span>
+              </dd>
+            </div>
             <div className="sm:col-span-2"> {/* Cambiado a col-span-2 para dar más espacio */}
               <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-2">
                 Descripción

--- a/resources/js/pages/Estanteria/index.tsx
+++ b/resources/js/pages/Estanteria/index.tsx
@@ -43,6 +43,8 @@ type IndexProps = {
     to: number | null;
     has_pages: boolean;
   };
+  all_secciones?: Array<{ id: number; nombre: string }>;
+  seccionId?: number | null;
 };
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -169,7 +171,9 @@ const Index = ({
   flash, 
   errors = {}, 
   filters: initialFilters = {},
-  pagination
+  pagination,
+  all_secciones = [],
+  seccionId = null
 }: IndexProps) => {
   const page = usePage();
 
@@ -299,6 +303,8 @@ const Index = ({
               onSuccess={(message) => showAlert('success', message)}
               onError={(message) => showAlert('error', message)}
               errors={errors}
+              all_secciones={all_secciones}
+              seccionId={seccionId}
             />
           </div>
         </div>
@@ -316,6 +322,7 @@ const Index = ({
               <colgroup>
                 <col className="w-16" />
                 <col className="w-32" />
+                <col className="w-32" />
                 <col className="w-48" />
                 <col className="w-28" />
               </colgroup>
@@ -323,6 +330,7 @@ const Index = ({
                 <tr className="bg-gray-50 dark:bg-gray-700">
                   <th className="px-4 py-4 text-center text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider border-b border-gray-200 dark:border-gray-600">N°</th>
                   <th className="px-4 py-4 text-left text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider border-b border-gray-200 dark:border-gray-600">Código</th>
+                  <th className="px-4 py-4 text-left text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider border-b border-gray-200 dark:border-gray-600">Sección</th>
                   <th className="px-4 py-4 text-left text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider border-b border-gray-200 dark:border-gray-600">Descripción</th>
                   <th className="px-4 py-4 text-center text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider border-b border-gray-200 dark:border-gray-600">Acciones</th>
                 </tr>
@@ -339,6 +347,11 @@ const Index = ({
                           {estanteria.cod_estante}
                         </div>
                       </td>
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300 text-sm">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                          {estanteria.seccion?.nombre || 'Sin sección'}
+                        </span>
+                      </td>
                       <td className="px-4 py-3 text-gray-700 dark:text-gray-300 text-sm align-top">
                         <ExpandableDescription text={estanteria.descripcion} maxLength={50} />
                       </td>
@@ -350,6 +363,8 @@ const Index = ({
                             onSuccess={(message) => showAlert('success', message)}
                             onError={(message) => showAlert('error', message)}
                             errors={errors}
+                            all_secciones={all_secciones}
+                            seccionId={seccionId}
                           />
                         </div>
                       </td>
@@ -357,7 +372,7 @@ const Index = ({
                   ))
                 ) : (
                   <tr>
-                    <td colSpan={4} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
+                    <td colSpan={5} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
                       No hay estanterías disponibles
                     </td>
                   </tr>

--- a/resources/js/pages/Estanteria/types.ts
+++ b/resources/js/pages/Estanteria/types.ts
@@ -4,6 +4,11 @@ export type Estanteria = {
   id: number;
   cod_estante: string;
   descripcion: string | null;
+  seccion_id: number;
+  seccion?: {
+    id: number;
+    nombre: string;
+  };
   position: number;
   created_at?: string;
   updated_at?: string;
@@ -22,4 +27,5 @@ export type BreadcrumbItem = {
 export type EstanteriaFormData = {
   cod_estante: string;
   descripcion: string | null;
+  seccion_id: number;
 };

--- a/resources/js/pages/Grado/Create.tsx
+++ b/resources/js/pages/Grado/Create.tsx
@@ -8,16 +8,18 @@ type CreateModalProps = {
   onSuccess: (message: string) => void;
   onError: (message: string) => void;
   errors?: Record<string, string>;
+  secciones?: Array<{ id: number; nombre: string }>;
+  seccionId?: number | null;
 };
 
-export default function CreateGrado({ onSuccess, onError, errors = {} }: CreateModalProps) {
+export default function CreateGrado({ onSuccess, onError, errors = {}, secciones = [], seccionId = null }: CreateModalProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const { data, setData, post, processing, reset, errors: formErrors, setError, clearErrors } = useForm({
     grado: '',
     subGrado: '',
     estado: 'ACTIVO',
-    seccion_id: '',
+    seccion_id: seccionId ? String(seccionId) : '',
   });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -86,10 +88,13 @@ export default function CreateGrado({ onSuccess, onError, errors = {} }: CreateM
       required: true,
       value: data.seccion_id,
       onChange: handleChange,
+      disabled: true, // Bloquear la edición de la sección
       options: [
         { value: '', label: 'Seleccione una sección' },
-        { value: '1', label: 'Primaria' },
-        { value: '2', label: 'Bachillerato' },
+        ...secciones.map(seccion => ({
+          value: String(seccion.id),
+          label: seccion.nombre
+        }))
       ],
     },
   ];
@@ -172,7 +177,11 @@ export default function CreateGrado({ onSuccess, onError, errors = {} }: CreateM
       >
         <Form
           initialData={data}
-          fields={gradoFields}
+          fields={gradoFields.map(field => ({
+            ...field,
+            onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => 
+              handleChange(e as React.ChangeEvent<HTMLInputElement | HTMLSelectElement>)
+          }))}
           errors={formErrors}
           submitUrl="/grados"
           method="post"

--- a/resources/js/pages/Grado/Edit.tsx
+++ b/resources/js/pages/Grado/Edit.tsx
@@ -10,6 +10,7 @@ type EditModalProps = {
   onSuccess: (message: string) => void;
   onError: (message: string) => void;
   errors?: Record<string, string>;
+  secciones?: Array<{ id: number; nombre: string }>;
 };
 
 type FieldConfig = {
@@ -23,7 +24,7 @@ type FieldConfig = {
   options?: { value: string; label: string }[];
 };
 
-export default function EditGrado({ grado, onSuccess, onError, errors = {} }: EditModalProps) {
+export default function EditGrado({ grado, onSuccess, onError, errors = {}, secciones = [] }: EditModalProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -138,10 +139,13 @@ export default function EditGrado({ grado, onSuccess, onError, errors = {} }: Ed
       required: true,
       value: data.seccion_id,
       onChange: handleChange,
+      // Removed disabled property since it's not defined in FieldConfig type
       options: [
         { value: '', label: 'Seleccione una sección' },
-        { value: '1', label: 'Primaria' },
-        { value: '2', label: 'Bachillerato' },
+        ...secciones.map(seccion => ({
+          value: String(seccion.id),
+          label: seccion.nombre
+        }))
       ],
     },
   ];
@@ -245,7 +249,11 @@ export default function EditGrado({ grado, onSuccess, onError, errors = {} }: Ed
       >
         <Form
           initialData={data}
-          fields={gradoFields}
+          fields={gradoFields.map(field => ({
+            ...field,
+            onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => 
+              field.onChange(e as React.ChangeEvent<HTMLInputElement | HTMLSelectElement>)
+          }))}
           errors={formErrors}
           submitUrl={`/grados/${grado.id}`}
           method="put"

--- a/resources/js/pages/Grado/Index.tsx
+++ b/resources/js/pages/Grado/Index.tsx
@@ -96,6 +96,7 @@ const Index = ({
   all_grados = [],
   all_estados = [],
   all_secciones = [],
+  seccionId = null,
   pagination
 }: IndexProps) => {
   const page = usePage();
@@ -366,6 +367,8 @@ const Index = ({
               onSuccess={(message) => showAlert('success', message)}
               onError={(message) => showAlert('error', message)}
               errors={errors}
+              secciones={all_secciones}
+              seccionId={seccionId}
             />
           </div>
         </div>
@@ -516,6 +519,7 @@ const Index = ({
                             onSuccess={(message) => showAlert('success', message)}
                             onError={(message) => showAlert('error', message)}
                             errors={errors}
+                            secciones={all_secciones}
                           />
                         </div>
                       </td>
@@ -641,4 +645,4 @@ const Index = ({
   );
 };
 
-export default Index; 
+export default Index;

--- a/resources/js/pages/Grado/types.ts
+++ b/resources/js/pages/Grado/types.ts
@@ -68,6 +68,7 @@ export type IndexProps = {
   all_grados?: string[];
   all_estados?: string[];
   all_secciones?: Seccion[];
+  seccionId?: number | null;
   pagination?: {
     current_page: number;
     last_page: number;

--- a/resources/js/pages/Libro/Create.tsx
+++ b/resources/js/pages/Libro/Create.tsx
@@ -28,6 +28,7 @@ export default function Create({
   estanterias = [],
   secciones = [],
   categoriasDewey = [],
+  seccionId = null, // Sección predeterminada según el rol del usuario
 }: LibroPageProps) {
   const [activeSection, setActiveSection] = useState('general');
   
@@ -43,7 +44,7 @@ export default function Create({
     isbn: '',
     titulo: '',
     contenido: '',
-    seccion_id: '',
+    seccion_id: seccionId || '', // Usar la sección predeterminada según el rol
     autor_id: '',
     editorial_id: '',
     clase: '',

--- a/resources/js/pages/Libro/Edit.tsx
+++ b/resources/js/pages/Libro/Edit.tsx
@@ -117,6 +117,7 @@ export default function Edit({
   temasDewey = [],
   clases = [],
   idiomas = [],
+  seccionId = null,
   flash,
   errors = {}
 }: EditLibroPageProps) {
@@ -183,6 +184,13 @@ export default function Edit({
       });
     }
   }, [flash, page.props.flash]);
+  
+  // Efecto para establecer la sección automáticamente según el rol del usuario
+  useEffect(() => {
+    if (seccionId !== null) {
+      setData('seccion_id', seccionId.toString());
+    }
+  }, [seccionId]);
 
   // Efecto para manejar errores de validación
   useEffect(() => {
@@ -498,12 +506,13 @@ export default function Edit({
                         </label>
                         <select
                           id="seccion_id"
+                          disabled={seccionId !== null}
                           name="seccion_id"
                           value={data.seccion_id}
                           onChange={handleChange}
-                          className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-3 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                          className={`w-full rounded-lg border border-gray-300 dark:border-gray-600 ${seccionId !== null ? 'bg-gray-100 dark:bg-gray-800' : 'bg-white dark:bg-gray-700'} px-4 py-3 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors`}
                         >
-                          <option value="">Seleccione una sección</option>
+                          <option value="">{seccionId !== null ? 'Sección asignada automáticamente' : 'Seleccione una sección'}</option>
                           {secciones.map((seccion: any) => (
                             <option key={seccion.id} value={seccion.id}>
                               {seccion.nombre}

--- a/resources/js/pages/Libro/FormCreate/GeneralInfoSection.tsx
+++ b/resources/js/pages/Libro/FormCreate/GeneralInfoSection.tsx
@@ -177,15 +177,16 @@ export default function GeneralInfoSection({
           "col-span-1 md:col-span-1 xl:col-span-1"
         )}
         
-        {/* Sección */}
+        {/* Sección - Automática según el rol del usuario */}
         {renderFormField('seccion_id', 'Sección', true, 
           <select
             id="seccion_id"
             value={form.data.seccion_id}
             onChange={e => form.setData('seccion_id', e.target.value)}
-            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 px-3 py-2 text-sm"
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 px-3 py-2 text-sm bg-gray-100 dark:bg-gray-800"
+            disabled={true}
           >
-            <option value="">Seleccione una sección</option>
+            <option value="">Sección asignada automáticamente</option>
             {secciones.map(seccion => (
               <option key={seccion.id} value={seccion.id}>
                 {seccion.nombre}

--- a/resources/js/pages/Libro/index.tsx
+++ b/resources/js/pages/Libro/index.tsx
@@ -20,6 +20,11 @@ interface Estanteria {
   cod_estante: string;
 }
 
+interface Seccion {
+  id: number;
+  nombre: string;
+}
+
 interface Libro {
   id: number;
   isbn: string;
@@ -28,6 +33,7 @@ interface Libro {
   ejemplares_count: number;
   autor?: Autor;
   estanteria?: Estanteria;
+  seccion?: Seccion;
 }
 
 interface PaginatedLibros {
@@ -54,6 +60,7 @@ interface LibroPageProps {
   idiomas: string[];
   estanterias: Estanteria[];
   filters: FilterOptions;
+  seccionId?: number | null;
   flash?: {
     success?: string;
     error?: string;
@@ -399,6 +406,7 @@ const Index: React.FC<LibroPageProps> = ({
   idiomas,
   estanterias = [],
   filters: initialFilters = {},
+  seccionId,
   flash,
   errors = {}
 }) => {
@@ -601,6 +609,7 @@ const Index: React.FC<LibroPageProps> = ({
                 <col className="w-44" />
                 <col className="w-24" />
                 <col className="w-24" />
+                <col className="w-24" />
                 <col className="w-20" />
                 <col className="w-32" />
               </colgroup>
@@ -611,6 +620,7 @@ const Index: React.FC<LibroPageProps> = ({
                   <th className="px-4 py-4 text-left text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider">Título</th>
                   <th className="px-4 py-4 text-left text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider">Autor</th>
                   <th className="px-4 py-4 text-left text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider">Sign. Top.</th>
+                  <th className="px-4 py-4 text-left text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider">Sección</th>
                   <th className="px-4 py-4 text-left text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider">Estantería</th>
                   <th className="px-3 py-4 text-center text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider">Ej.Disp</th>
                   <th className="px-4 py-4 text-center text-xs font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider">Acciones</th>
@@ -635,6 +645,9 @@ const Index: React.FC<LibroPageProps> = ({
                         </div>
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap text-gray-700 dark:text-gray-300 text-sm">{libro.sign_top || '-'}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-gray-700 dark:text-gray-300 text-sm">
+                        {libro.seccion ? libro.seccion.nombre : '-'}
+                      </td>
                       <td className="px-4 py-3 whitespace-nowrap text-gray-700 dark:text-gray-300 text-sm">
                         {libro.estanteria ? libro.estanteria.cod_estante : '-'}
                       </td>
@@ -677,7 +690,7 @@ const Index: React.FC<LibroPageProps> = ({
                   ))
                 ) : (
                   <tr>
-                    <td colSpan={8} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
+                    <td colSpan={9} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
                       No hay libros disponibles
                     </td>
                   </tr>

--- a/resources/js/pages/Libro/types.ts
+++ b/resources/js/pages/Libro/types.ts
@@ -153,6 +153,7 @@ export interface LibroPageProps extends InertiaPageProps {
   estanterias?: Estanteria[];
   secciones?: Seccion[];
   categoriasDewey?: CategoriaDewey[];
+  seccionId?: number | null; // ID de la sección predeterminada según el rol del usuario
 }
 
 // Interfaz específica para las props de la página de edición de libros
@@ -167,6 +168,7 @@ export interface EditLibroPageProps extends InertiaPageProps {
   temasDewey: TemaDewey[];
   clases: string[];
   idiomas: string[];
+  seccionId?: number | null; // ID de la sección predeterminada según el rol del usuario
   success?: string;
 }
 

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -29,10 +29,23 @@ export default function Login({ status, canResetPassword }: LoginProps) {
 
     const [showPassword, setShowPassword] = useState(false);
     const [mounted, setMounted] = useState(false);
+    const [errorVisible, setErrorVisible] = useState(false);
 
     useEffect(() => {
         setMounted(true);
     }, []);
+
+    // Efecto para manejar la visibilidad de los errores
+    useEffect(() => {
+        if (Object.keys(errors).length > 0) {
+            setErrorVisible(true);
+            const timer = setTimeout(() => {
+                setErrorVisible(false);
+            }, 5000); // Ocultar después de 5 segundos
+            
+            return () => clearTimeout(timer);
+        }
+    }, [errors]);
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
@@ -133,7 +146,7 @@ export default function Login({ status, canResetPassword }: LoginProps) {
                                     />
                                     <div className="absolute right-0 top-0 bottom-0 w-1 bg-blue-200 dark:bg-blue-700 rounded-r-md opacity-50"></div>
                                 </div>
-                                <InputError message={errors.email} />
+                                {errorVisible && <InputError message={errors.email} />}
                             </div>
 
                             {/* Password */}
@@ -164,7 +177,7 @@ export default function Login({ status, canResetPassword }: LoginProps) {
                                     </button>
                                     <div className="absolute right-0 top-0 bottom-0 w-1 bg-blue-200 dark:bg-blue-700 rounded-r-md opacity-50"></div>
                                 </div>
-                                <InputError message={errors.password} />
+                                {errorVisible && <InputError message={errors.password} />}
                             </div>
 
                             {/* Recordarme y Olvidé contraseña */}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -5,6 +5,8 @@
         <meta name="csrf-token" content="{{ csrf_token() }}">
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        {{-- Desactivar advertencias de lazy loading --}}
+        <meta http-equiv="origin-trial" content="AlpPPj7z2ySoFxPtuTlEp77ypX1P1Sx3Tg7G9CL/+ESzEQJUxCnG5st0QUh41jUNVPxwKUF+0LXyA5T+UhkuDgsAAABfeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwMDAiLCJmZWF0dXJlIjoiTGF6eUltYWdlTWluaW1hbEluaXRpYWxJbWFnZVJlcXVlc3RzIiwiZXhwaXJ5IjoxNzE5MzU5OTk5fQ==">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Session;
 use Inertia\Inertia;
 use App\Http\Controllers\AutorController;
 use App\Http\Controllers\CoautorController;
@@ -17,6 +19,18 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\InformeController;
 use App\Http\Controllers\InventarioController;
 use App\Http\Controllers\ExcelTestController;
+
+// Ruta para refrescar el token CSRF
+Route::get('/csrf-refresh', function () {
+    // Regenerar el token CSRF
+    Session::regenerateToken();
+    
+    // Devolver el nuevo token como respuesta JSON
+    return Response::json([
+        'token' => csrf_token(),
+        'status' => 'success'
+    ]);
+});
 
 Route::get('/', function () {
     return Inertia::render('welcome');
@@ -45,34 +59,47 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Rutas para EstanteriaController
     Route::get('estanterias', [EstanteriaController::class, 'index'])->name('estanterias.index');
-    Route::get('estanterias/create', [EstanteriaController::class, 'create'])->name('estanterias.create');
-    Route::post('estanterias', [EstanteriaController::class, 'store'])->name('estanterias.store');
     Route::get('estanterias/{estanteria}', [EstanteriaController::class, 'show'])->name('estanterias.show');
-    Route::get('estanterias/{estanteria}/edit', [EstanteriaController::class, 'edit'])->name('estanterias.edit');
-    Route::put('estanterias/{estanteria}', [EstanteriaController::class, 'update'])->name('estanterias.update');
-    Route::patch('estanterias/{estanteria}', [EstanteriaController::class, 'update']);
-    Route::delete('estanterias/{estanteria}', [EstanteriaController::class, 'destroy'])->name('estanterias.destroy');
+    
+    // Rutas protegidas por middleware de roles para estanterías (solo administrador o bibliotecarios)
+    Route::middleware('role:Administrador|BibliotecarioPrimaria|BibliotecarioBachillerato')->group(function () {
+        Route::get('estanterias/create', [EstanteriaController::class, 'create'])->name('estanterias.create');
+        Route::post('estanterias', [EstanteriaController::class, 'store'])->name('estanterias.store');
+        Route::get('estanterias/{estanteria}/edit', [EstanteriaController::class, 'edit'])->name('estanterias.edit');
+        Route::put('estanterias/{estanteria}', [EstanteriaController::class, 'update'])->name('estanterias.update');
+        Route::patch('estanterias/{estanteria}', [EstanteriaController::class, 'update']);
+        Route::delete('estanterias/{estanteria}', [EstanteriaController::class, 'destroy'])->name('estanterias.destroy');
+    });
 
     // Rutas para LibroController
     Route::get('libros', [LibroController::class, 'index'])->name('libros.index');
     Route::get('libros/search', [LibroController::class, 'search'])->name('libros.search');
-    Route::get('libros/create', [LibroController::class, 'create'])->name('libros.create');
-    Route::post('libros', [LibroController::class, 'store'])->name('libros.store');
+    
+    // Rutas protegidas por middleware de roles (solo administrador o bibliotecarios)
+    Route::middleware('role:Administrador|BibliotecarioPrimaria|BibliotecarioBachillerato')->group(function () {
+        Route::get('libros/create', [LibroController::class, 'create'])->name('libros.create');
+        Route::post('libros', [LibroController::class, 'store'])->name('libros.store');
+        Route::get('libros/{libro}/edit', [LibroController::class, 'edit'])->name('libros.edit');
+        Route::put('libros/{libro}', [LibroController::class, 'update'])->name('libros.update');
+        Route::patch('libros/{libro}', [LibroController::class, 'update']);
+        Route::delete('libros/{libro}', [LibroController::class, 'destroy'])->name('libros.destroy');
+    });
+    
     Route::get('libros/{libro}', [LibroController::class, 'show'])->name('libros.show');
-    Route::get('libros/{libro}/edit', [LibroController::class, 'edit'])->name('libros.edit');
-    Route::put('libros/{libro}', [LibroController::class, 'update'])->name('libros.update');
-    Route::patch('libros/{libro}', [LibroController::class, 'update']);
-    Route::delete('libros/{libro}', [LibroController::class, 'destroy'])->name('libros.destroy');
 
     // Rutas de Ejemplares
     Route::get('libros/{libro}/ejemplares', [EjemplarController::class, 'index'])->name('ejemplares.index');
-    Route::get('libros/{libro}/ejemplares/create', [EjemplarController::class, 'create'])->name('ejemplares.create');
-    Route::post('libros/{libro}/ejemplares', [EjemplarController::class, 'store'])->name('ejemplares.store');
     Route::get('libros/{libro}/ejemplares/{ejemplar}', [EjemplarController::class, 'show'])->name('ejemplares.show');
-    Route::get('libros/{libro}/ejemplares/{ejemplar}/edit', [EjemplarController::class, 'edit'])->name('ejemplares.edit');
-    Route::put('libros/{libro}/ejemplares/{ejemplar}', [EjemplarController::class, 'update'])->name('ejemplares.update');
-    Route::patch('libros/{libro}/ejemplares/{ejemplar}', [EjemplarController::class, 'update']);
-    Route::delete('libros/{libro}/ejemplares/{ejemplar}', [EjemplarController::class, 'destroy'])->name('ejemplares.destroy');
+    
+    // Rutas de Ejemplares protegidas por middleware de roles
+    Route::middleware('role:Administrador|BibliotecarioPrimaria|BibliotecarioBachillerato')->group(function () {
+        Route::get('libros/{libro}/ejemplares/create', [EjemplarController::class, 'create'])->name('ejemplares.create');
+        Route::post('libros/{libro}/ejemplares', [EjemplarController::class, 'store'])->name('ejemplares.store');
+        Route::get('libros/{libro}/ejemplares/{ejemplar}/edit', [EjemplarController::class, 'edit'])->name('ejemplares.edit');
+        Route::put('libros/{libro}/ejemplares/{ejemplar}', [EjemplarController::class, 'update'])->name('ejemplares.update');
+        Route::patch('libros/{libro}/ejemplares/{ejemplar}', [EjemplarController::class, 'update']);
+        Route::delete('libros/{libro}/ejemplares/{ejemplar}', [EjemplarController::class, 'destroy'])->name('ejemplares.destroy');
+    });
 
     // Rutas adicionales para las funciones AJAX de clasificación Dewey
     Route::get('api/categorias/{categoriaId}/subcategorias', [LibroController::class, 'getSubcategorias']);
@@ -80,13 +107,17 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Rutas para grados
     Route::get('grados', [GradoController::class, 'index'])->name('grados.index');
-    Route::get('grados/create', [GradoController::class, 'create'])->name('grados.create');
-    Route::post('grados', [GradoController::class, 'store'])->name('grados.store');
     Route::get('grados/{grado}', [GradoController::class, 'show'])->name('grados.show');
-    Route::get('grados/{grado}/edit', [GradoController::class, 'edit'])->name('grados.edit');
-    Route::put('grados/{grado}', [GradoController::class, 'update'])->name('grados.update');
-    Route::patch('grados/{grado}', [GradoController::class, 'update']);
-    Route::delete('grados/{grado}', [GradoController::class, 'destroy'])->name('grados.destroy');
+    
+    // Rutas protegidas por middleware de roles para grados (solo administrador o bibliotecarios)
+    Route::middleware('role:Administrador|BibliotecarioPrimaria|BibliotecarioBachillerato')->group(function () {
+        Route::get('grados/create', [GradoController::class, 'create'])->name('grados.create');
+        Route::post('grados', [GradoController::class, 'store'])->name('grados.store');
+        Route::get('grados/{grado}/edit', [GradoController::class, 'edit'])->name('grados.edit');
+        Route::put('grados/{grado}', [GradoController::class, 'update'])->name('grados.update');
+        Route::patch('grados/{grado}', [GradoController::class, 'update'])->name('grados.patch');
+        Route::delete('grados/{grado}', [GradoController::class, 'destroy'])->name('grados.destroy');
+    });
 
     // Rutas para LectorController
     Route::get('lectores', [LectorController::class, 'index'])->name('lectores.index');


### PR DESCRIPTION
Añadir permisos basados ​​en roles para bibliotecarios con restricciones específicas por sección. Incluye:
- Dividir el rol de bibliotecario en Primaria/Bachillerato
- Añadir seccion_id a usuarios, estanterías y libros
- Middleware para validar el acceso a secciones
- Asignar automáticamente secciones según el rol
- Actualizar la interfaz de usuario para reflejar las restricciones de las secciones